### PR TITLE
Allow ForwardDiffChainRules v0.3, and thus ForwardDiff v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiableEigen"
 uuid = "73a20539-4e65-4dcb-a56d-dc20f210a01b"
 authors = ["TT <tobias.thummerer@informatik.uni-augsburg.de>", "LM <lars.mikelsons@informatik.uni-augsburg.de>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 ForwardDiffChainRules = "c9556dd2-1aed-4cfe-8560-1557cf593001"
@@ -9,7 +9,7 @@ ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-ForwardDiffChainRules = "0.1, 0.2"
+ForwardDiffChainRules = "0.1, 0.2, 0.3"
 ReverseDiff = "1.9"
 LinearAlgebra = "1"
 julia = "1.6"


### PR DESCRIPTION
https://github.com/ThummeTo/ForwardDiffChainRules.jl has a version 0.3, which this package currently doesn't accept. Doing so would allow it to be used with ForwardDiff.jl version 1.0.

I haven't checked anything locally.